### PR TITLE
deploy: Github Actions를 위한 workflows 추가

### DIFF
--- a/backend/.github/workflows/peach-picker-be-publish.yml
+++ b/backend/.github/workflows/peach-picker-be-publish.yml
@@ -1,0 +1,66 @@
+name: CD with backend
+
+# "staging"에 push 할때 트리거 발동
+on:
+  push:
+    branches: [ "staging" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          # server-id: github # Value of the distributionManagement/repository/id field of the pom.xml
+          # settings-path: ${{ github.workspace }} # location for the settings.xml file
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@417ae3ccd767c252f5661f1ace9f835f9654f2b5 # v3.1.0
+
+      # - name: Make application.properties
+      #   run: |
+      #      cd ./src/main/resources
+      #      touch ./application.properties
+      #      echo "${{ secrets.PROPERTIES }}" > ./application.properties
+      #   shell: bash
+
+      - name: Build with Gradle
+        run: |
+          cd backend
+          ./gradlew build
+      - name: Docker build & push to docker repo
+        run: |
+          cd backend
+          docker login -u ${{ secrets.DOCKER_USERNAME }} -p ${{ secrets.DOCKER_PASSWORD }}
+          docker build -t ${{ secrets.DOCKER_REPO }}/peach-picker-be:${{ github.sha }} .
+          docker push ${{ secrets.DOCKER_REPO }}/peach-picker-be:${{ github.sha }}
+
+      - name: Deploy to Kubernetes
+        uses: Gabryel8818/kubectl@v1.0.1
+        env:
+          BASE64_KUBE_CONFIG: ${{ secrets.KUBECONFIG }}
+          KUBECTL_VERSION: '1.29.3'
+        with:
+          args: set image deployment/peach-picker-be peach-picker-be=${{ secrets.DOCKER_USERNAME }}/peach-picker-be:${{ github.sha }} -n peach-picker
+
+    #- name: Deploy to Kubernetes
+    #  env:
+    #    KUBECONFIG: ${{ secrets.KUBECONFIG }}
+    #  run: |
+    #    kubectl set image deployment/peach-picker-be peach-picker-be=${{ secrets.DOCKER_USERNAME }}/peach-picker-be:latest
+
+    # # The USERNAME and TOKEN need to correspond to the credentials environment variables used in
+    # # the publishing section of your build.gradle
+    # - name: Publish to GitHub Packages
+    #   run: ./gradlew publish
+    #   env:
+    #     USERNAME: ${{ github.actor }}
+    #     TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
- 제목 : feat(#13): CICD backend

## 🔘Part

- [x] BE

<br/>

## 🔎 작업 내용

- java build workflows 작성
- docker build 및 docker hub push workflows 작성
- 서버의 kubernetes에 배포
- kubernetes에 배포시 도커 이미지 태그 변경

<br/>

## 🔧 앞으로의 과제

application.yaml 파일을 github에 올릴 수 없기 때문에 서버에 어떻게 올릴지 고민해보자

<br/>
