### PR TITLE
feat: 카카오 회원가입 및 로그인 구현

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -63,6 +63,9 @@ dependencies {
     // etc
     annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
 
+    // WebClient
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
+
 }
 
 tasks.named('test') {

--- a/backend/src/main/java/com/peach/backend/domain/user/controller/UserController.java
+++ b/backend/src/main/java/com/peach/backend/domain/user/controller/UserController.java
@@ -1,5 +1,6 @@
 package com.peach.backend.domain.user.controller;
 
+import com.peach.backend.domain.user.dto.kakao.KakaoCodeReq;
 import com.peach.backend.domain.user.dto.req.SignInReq;
 import com.peach.backend.domain.user.dto.req.SignUpReq;
 import com.peach.backend.domain.user.dto.resp.ProfileResp;
@@ -9,7 +10,6 @@ import com.peach.backend.domain.user.facade.UserFacade;
 import com.peach.backend.global.security.dto.CurrentUser;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -28,23 +28,11 @@ public class UserController {
         return ResponseEntity.ok("회원가입이 완료되었습니다.");
     }
 
-    // TODO
-    // 지홍이 구현 예정
-    @PostMapping("kakao-sign-up")
-    public ResponseEntity<String> signUpWithKakao() {
-        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("구현 중입니다.");
-    }
-
     @PostMapping("sign-in")
     public SignInResp signIn(@RequestBody SignInReq req) {
         return userFacade.signIn(req);
     }
 
-    // TODO
-    // 지홍이 구현 예정
-    public SignInResp signInWithKakao() {
-        return null;
-    }
 
     // TODO
     @GetMapping("/profile")
@@ -52,4 +40,8 @@ public class UserController {
         return userFacade.getUserProfile(user);
     }
 
+    @PostMapping("kakao-login")
+    public ResponseEntity<SignInResp> kakaoLogin(@RequestBody KakaoCodeReq kakaoReq) {
+        return ResponseEntity.ok(userFacade.KakaoLogin(kakaoReq));
+    }
 }

--- a/backend/src/main/java/com/peach/backend/domain/user/dto/kakao/KakaoCodeReq.java
+++ b/backend/src/main/java/com/peach/backend/domain/user/dto/kakao/KakaoCodeReq.java
@@ -1,0 +1,8 @@
+package com.peach.backend.domain.user.dto.kakao;
+
+import lombok.Data;
+
+@Data
+public class KakaoCodeReq {
+    private String code;
+}

--- a/backend/src/main/java/com/peach/backend/domain/user/dto/kakao/KakaoProfile.java
+++ b/backend/src/main/java/com/peach/backend/domain/user/dto/kakao/KakaoProfile.java
@@ -1,0 +1,38 @@
+package com.peach.backend.domain.user.dto.kakao;
+
+import lombok.Data;
+
+@Data
+public class KakaoProfile {
+    public String id;
+    public String connected_at;
+    public Properties properties;
+    public KakaoAccount kakao_account;
+
+    public class Properties {
+        public String nickname;
+        public String profile_image;
+        public String thumbnail_image;
+    }
+
+    @Data
+    public class KakaoAccount {
+        public Boolean profile_nickname_needs_agreement;
+        public Boolean profile_image_needs_agreement;
+        public Profile profile;
+        public Boolean has_email;
+        public Boolean email_needs_agreement;
+        public Boolean is_email_valid;
+        public Boolean is_email_verified;
+        public String email;
+
+        @Data
+        public class Profile {
+            public String nickname;
+            public String thumbnail_image_url;
+            public String profile_image_url;
+            public Boolean is_default_image;
+            public Boolean is_default_nickname;
+        }
+    }
+}

--- a/backend/src/main/java/com/peach/backend/domain/user/dto/kakao/KakaoToken.java
+++ b/backend/src/main/java/com/peach/backend/domain/user/dto/kakao/KakaoToken.java
@@ -1,0 +1,15 @@
+package com.peach.backend.domain.user.dto.kakao;
+
+import lombok.Data;
+
+@Data
+public class KakaoToken {
+
+    private String access_token;
+    private String token_type;
+    private String refresh_token;
+    private String id_token;
+    private int expires_in;
+    private String scope;
+    private int refresh_token_expires_in;
+}

--- a/backend/src/main/java/com/peach/backend/domain/user/entity/User.java
+++ b/backend/src/main/java/com/peach/backend/domain/user/entity/User.java
@@ -7,8 +7,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
-import org.hibernate.annotations.ColumnDefault;
-import org.springframework.data.redis.core.RedisHash;
+
+import java.time.LocalDateTime;
 
 
 @NoArgsConstructor
@@ -30,14 +30,24 @@ public class User extends BaseTimeEntity {
     private Role role;
     private Boolean kakaoSignUp;
     private String profileImgUrl;
+    private LocalDateTime recentLoggedIn;
+    private String provider;
+    private String providerId;
 
     @Builder
-    public User(String email, String password, String name, Role role, Boolean kakaoSignUp, String profileImgUrl) {
+    public User(String email, String password, String name, Role role, Boolean kakaoSignUp, String profileImgUrl, LocalDateTime RecentLoggedIn, String provider, String providerId) {
         this.email = email;
         this.password = password;
         this.name = name;
         this.role = role;
         this.kakaoSignUp = kakaoSignUp;
         this.profileImgUrl = profileImgUrl;
+        this.recentLoggedIn = RecentLoggedIn;
+        this.provider = provider;
+        this.providerId = providerId;
+    }
+
+    public void updateRecentLoggedIn(){
+        recentLoggedIn = LocalDateTime.now();
     }
 }

--- a/backend/src/main/java/com/peach/backend/domain/user/facade/UserFacade.java
+++ b/backend/src/main/java/com/peach/backend/domain/user/facade/UserFacade.java
@@ -1,5 +1,6 @@
 package com.peach.backend.domain.user.facade;
 
+import com.peach.backend.domain.user.dto.kakao.KakaoCodeReq;
 import com.peach.backend.domain.user.dto.req.SignInReq;
 import com.peach.backend.domain.user.dto.req.SignUpReq;
 import com.peach.backend.domain.user.dto.resp.ProfileResp;
@@ -7,6 +8,7 @@ import com.peach.backend.domain.user.dto.resp.SignInResp;
 import com.peach.backend.domain.user.entity.User;
 import com.peach.backend.domain.user.service.CreateUserService;
 import com.peach.backend.domain.user.service.GetUserService;
+import com.peach.backend.domain.user.service.KakaoLoginService;
 import com.peach.backend.global.security.util.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -17,6 +19,7 @@ public class UserFacade {
 
     private final CreateUserService createUserService;
     private final GetUserService getUserService;
+    private final KakaoLoginService kakaoLoginService;
     private final JwtTokenProvider jwtTokenProvider;
 
     public void signUp(SignUpReq req) {
@@ -35,4 +38,10 @@ public class UserFacade {
         return getUserService.getUserProfileByJwtToken(user);
     }
 
+    public SignInResp KakaoLogin(KakaoCodeReq req) {
+        User user = kakaoLoginService.kakaoLogin(req);
+        return SignInResp.builder()
+                .accessToken(jwtTokenProvider.generateAccessToken(user.getEmail()))
+                .build();
+    }
 }

--- a/backend/src/main/java/com/peach/backend/domain/user/service/CreateUserService.java
+++ b/backend/src/main/java/com/peach/backend/domain/user/service/CreateUserService.java
@@ -14,17 +14,14 @@ public class CreateUserService {
     private final UserRepository userRepository;
     private final BCryptPasswordEncoder passwordEncoder;
 
+
     public void createUser(final SignUpReq req) {
-        if(duplicateEmailCheck(req.getEmail())) throw UserAlreadyExistException.EXCEPTION;
+        if (duplicateEmailCheck(req.getEmail())) throw UserAlreadyExistException.EXCEPTION;
 
         userRepository.save(req.toEntity(passwordEncoder));
     }
 
-    // TODO
-    // 카카오 로그인 로직
-    public void createUserWithKakao() {
 
-    }
     private Boolean duplicateEmailCheck(String email) {
         return userRepository.existsByEmail(email);
     }

--- a/backend/src/main/java/com/peach/backend/domain/user/service/KakaoLoginService.java
+++ b/backend/src/main/java/com/peach/backend/domain/user/service/KakaoLoginService.java
@@ -1,0 +1,121 @@
+package com.peach.backend.domain.user.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.peach.backend.domain.user.dto.kakao.KakaoProfile;
+import com.peach.backend.domain.user.dto.kakao.KakaoToken;
+import com.peach.backend.domain.user.dto.kakao.KakaoCodeReq;
+import com.peach.backend.domain.user.entity.User;
+import com.peach.backend.domain.user.entity.repository.UserRepository;
+import com.peach.backend.domain.user.enums.Role;
+import com.peach.backend.domain.user.exception.UserNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.reactive.function.BodyInserters;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.time.LocalDateTime;
+import java.util.Random;
+
+@Service
+@RequiredArgsConstructor
+public class KakaoLoginService {
+    private final UserRepository userRepository;
+    @Value("${spring.security.oauth2.client.registration.kakao.client-id}")
+    private String kakaoClientId;
+    @Value("${spring.security.oauth2.client.registration.kakao.redirect-uri}")
+    private String kakaoRedirectUri;
+    @Value("${spring.security.oauth2.client.registration.kakao.client-secret}")
+    private String kakaoClientSecret;
+
+    public User kakaoLogin(KakaoCodeReq req) {
+        KakaoToken kakaoUserToken = createKakaoToken(req);
+        KakaoProfile kakaoProfile;
+        try {
+            kakaoProfile = getKakaoInfo(kakaoUserToken.getAccess_token());
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+
+        // 기존 회원이면
+        if (userRepository.existsByEmail(kakaoProfile.getKakao_account().email)) {
+            User user = userRepository.findUserByEmail(kakaoProfile.getKakao_account().email)
+                    .orElseThrow(() -> UserNotFoundException.EXCEPTION);
+
+            user.updateRecentLoggedIn();
+            userRepository.save(user);
+
+            return user;
+        } else {
+//            if (kakaoProfile.getKakao_account().profile.profile_image_url == null) {
+//                kakaoProfile(DEFAULT_PROFILE);
+//            }
+            Random random = new Random();
+
+            User user = User.builder()
+                    .email(kakaoProfile.getKakao_account().email)
+                    .name(kakaoProfile.properties.nickname)
+                    .RecentLoggedIn(LocalDateTime.now())
+                    .provider("kakao")
+                    .profileImgUrl(kakaoProfile.properties.profile_image)
+                    .role(Role.USER)
+                    .password(String.valueOf(random.nextInt(Integer.MAX_VALUE)))
+                    .build();
+            userRepository.save(user);
+            return user;
+        }
+    }
+
+    public KakaoToken createKakaoToken(KakaoCodeReq kakaoReq) {
+        MultiValueMap<String , String> params = new LinkedMultiValueMap<>();
+        params.add("grant_type", "authorization_code");
+        params.add("client_id",kakaoClientId );
+        params.add("redirect_uri", kakaoRedirectUri);
+        params.add("code", kakaoReq.getCode());
+        params.add("client_secret", kakaoClientSecret);
+
+        WebClient webClient = WebClient.builder().build();
+        String url = "https://kauth.kakao.com/oauth/token";
+
+        String resp = webClient.post()
+                .uri(url)
+                .header("Content-Type", "application/x-www-form-urlencoded")
+                .body(BodyInserters.fromFormData(params))
+                .retrieve()
+                .bodyToMono(String.class)
+                .block();
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        KakaoToken kakaoToken =null;
+
+        try {
+            kakaoToken = objectMapper.readValue(resp, KakaoToken.class);
+        } catch (JsonProcessingException e) {
+            e.printStackTrace();
+        }
+
+        return kakaoToken;
+    }
+
+    public KakaoProfile getKakaoInfo(String accessToken) throws JsonProcessingException {
+
+        WebClient webClient = WebClient.builder().build();
+        String url = "https://kapi.kakao.com/v2/user/me";
+
+        String resp = webClient.post()
+                .uri(url)
+                .header("Content-Type", "application/x-www-form-urlencoded;charset=utf-8")
+                .header("Authorization", "Bearer " + accessToken)
+                .retrieve()
+                .bodyToMono(String.class)
+                .block();
+
+
+        ObjectMapper objectMapper = new ObjectMapper();
+
+        return objectMapper.readValue(resp, KakaoProfile.class);
+    }
+}


### PR DESCRIPTION
- 제목 : feat(#25 ): 카카오 회원가입 및 로그인 구현

## 🔘Part

- [x] BE

  <br/>

## 🔎 작업 내용

- 프론트에서 카카오 code를 전달 받고, 기존회원이면 access_token 바로 전달 하고, 기존 회원이 아니라면 카카의 프로필을 조회하여 회원가입하고 access_token을 전달한다.


<br/>

## 🔧 앞으로의 과제

- redirect_url 실제 서버 웹 주소로 변경 예정

